### PR TITLE
feat: allow "Enter" key to complete create new list

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -325,6 +325,7 @@ impl Application for App {
                             .on_input(move |name| {
                                 Message::DialogUpdate(DialogPage::Rename { to: name })
                             })
+                            .on_submit(Message::DialogComplete)
                             .into(),
                     ])
                     .spacing(spacing.space_xxs),

--- a/src/app.rs
+++ b/src/app.rs
@@ -304,6 +304,7 @@ impl Application for App {
                         widget::text_input("", name.as_str())
                             .id(self.dialog_text_input.clone())
                             .on_input(move |name| Message::DialogUpdate(DialogPage::New(name)))
+                            .on_submit(Message::DialogComplete)
                             .into(),
                     ])
                     .spacing(spacing.space_xxs),


### PR DESCRIPTION
"Create a new list" dialog now allow the "Enter" key to finish creating the new list

![image](https://github.com/edfloreshz/cosmic-tasks/assets/39024711/a7de2012-59fb-46ee-a570-aad0d636f12c)

Same thing for the "Rename list" dialog.

![image](https://github.com/edfloreshz/cosmic-tasks/assets/39024711/da191c4b-2794-46fb-a831-4476ee9d43a9)
